### PR TITLE
Add user profile page with photo gallery

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,75 @@
+'use server';
+
+import Image from 'next/image';
+import { UserModel, PhotoModel } from '@/lib/database';
+
+export default async function ProfilePage() {
+  const userId = 1; // Demo user
+  const userModel = new UserModel();
+  const photoModel = new PhotoModel();
+
+  const user = userModel.getUserById(userId);
+  const photos = photoModel.getPhotosByUser(userId);
+
+  return (
+    <div className="max-w-6xl mx-auto px-5 py-8">
+      <h1 className="text-3xl font-bold mb-6 text-primary-100">My Profile</h1>
+      {user && (
+        <div className="flex items-center mb-8">
+          <div className="relative w-20 h-20 rounded-full overflow-hidden mr-4">
+            <Image
+              src={user.profile_image_url || 'https://via.placeholder.com/80'}
+              alt="Profile"
+              fill
+              className="object-cover"
+            />
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold text-primary-100">
+              {user.username}
+            </h2>
+            {user.bio && (
+              <p className="text-primary-300">{user.bio}</p>
+            )}
+            <p className="text-primary-300 mt-1">
+              Total Photos Uploaded: {photos.length}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <h3 className="text-2xl font-bold mb-4 text-primary-100">My Photos</h3>
+      {photos.length > 0 ? (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {photos.map(photo => (
+            <div key={photo.id} className="card relative group">
+              <div className="relative w-full h-40">
+                <Image
+                  src={photo.blob_url}
+                  alt={photo.alt_text || 'User photo'}
+                  fill
+                  className="object-cover"
+                />
+              </div>
+              <div className="p-2">
+                {photo.caption && (
+                  <p className="text-sm text-primary-200 mb-2">{photo.caption}</p>
+                )}
+                <div className="flex space-x-2">
+                  <button className="flex-1 bg-gray-700 text-white text-xs py-1 rounded hover:bg-gray-600 transition-colors">
+                    Edit
+                  </button>
+                  <button className="flex-1 bg-red-600 text-white text-xs py-1 rounded hover:bg-red-700 transition-colors">
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-primary-300">You haven&apos;t uploaded any photos yet.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import AuthModal from './AuthModal';
 
@@ -47,21 +48,27 @@ export default function Header({ onSearch, onReset, onShowPastEvents }: HeaderPr
     <header className="bg-primary-900/90 backdrop-blur-sm text-white p-5 mb-5 border-b border-primary-700">
       <div className="max-w-6xl mx-auto">
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-3xl font-bold text-accent-400">Buffalo Music Scene</h1>
+          <h1 className="text-3xl font-bold text-accent-400">Band Pics</h1>
           
           <div className="flex items-center space-x-4">
-            <button 
+            <button
               onClick={() => handleAuthClick('signup')}
               className="text-primary-200 hover:text-accent-400 transition-colors"
             >
               Sign Up
             </button>
-            <button 
+            <button
               onClick={() => handleAuthClick('login')}
               className="text-primary-200 hover:text-accent-400 transition-colors"
             >
               Log In
             </button>
+            <Link
+              href="/profile"
+              className="text-primary-200 hover:text-accent-400 transition-colors"
+            >
+              Profile
+            </Link>
           </div>
         </div>
         
@@ -134,10 +141,10 @@ export default function Header({ onSearch, onReset, onShowPastEvents }: HeaderPr
         </div>
         
         <div className="bg-gradient-to-r from-accent-800 to-primary-800 p-8 rounded-lg text-center border border-primary-600">
-          <h2 className="text-2xl font-bold mb-2 text-primary-100">Discover Buffalo&apos;s Music Scene</h2>
-          <p className="text-lg mb-4 text-primary-200">From the Goo Goo Dolls to local venues - explore the city&apos;s rich musical heritage</p>
+          <h2 className="text-2xl font-bold mb-2 text-primary-100">Discover Live Music Near You</h2>
+          <p className="text-lg mb-4 text-primary-200">Track your favorite artists and never miss a show</p>
           <button className="bg-blue-500 text-white font-bold py-2 px-6 rounded-full hover:bg-blue-700 transition-colors">
-            Explore Buffalo Music
+            Find Concerts
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update header text and add a Profile link
- implement a new `/profile` page showing user info and uploaded photos

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686896ab1ed08324a8bf811adde7b5db