### PR TITLE
Update photo upload success handling

### DIFF
--- a/__tests__/photoUploadComponent.test.tsx
+++ b/__tests__/photoUploadComponent.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@/hooks/usePhotoUpload', () => ({
     isUploading: false,
     uploadProgress: 0,
     uploadError: null,
-    uploadPhoto: jest.fn().mockResolvedValue(undefined)
+    uploadPhoto: jest.fn().mockResolvedValue(true)
   }))
 }));
 
@@ -82,7 +82,7 @@ describe('PhotoUpload Component', () => {
       isUploading: false,
       uploadProgress: 0,
       uploadError: 'Failed to upload photo',
-      uploadPhoto: jest.fn().mockResolvedValue(undefined)
+      uploadPhoto: jest.fn().mockResolvedValue(false)
     });
 
     render(
@@ -103,7 +103,7 @@ describe('PhotoUpload Component', () => {
       isUploading: true,
       uploadProgress: 50,
       uploadError: null,
-      uploadPhoto: jest.fn().mockResolvedValue(undefined)
+      uploadPhoto: jest.fn().mockResolvedValue(true)
     });
 
     render(

--- a/__tests__/usePhotoUpload.test.ts
+++ b/__tests__/usePhotoUpload.test.ts
@@ -54,11 +54,13 @@ describe('usePhotoUpload Hook', () => {
 
     const { result } = renderHook(() => usePhotoUpload(mockToken));
     
+    let success = false;
     await act(async () => {
-      await result.current.uploadPhoto(mockFile, mockPhotoData);
+      success = await result.current.uploadPhoto(mockFile, mockPhotoData);
     });
     
     expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(success).toBe(true);
     expect(result.current.uploadProgress).toBe(100);
     expect(result.current.isUploading).toBe(false);
     expect(result.current.uploadError).toBeNull();
@@ -75,11 +77,13 @@ describe('usePhotoUpload Hook', () => {
 
     const { result } = renderHook(() => usePhotoUpload(mockToken));
     
+    let success = false;
     await act(async () => {
-      await result.current.uploadPhoto(mockFile, mockPhotoData);
+      success = await result.current.uploadPhoto(mockFile, mockPhotoData);
     });
     
     expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(success).toBe(false);
     expect(result.current.uploadError).toBe('Failed to get upload URL');
     expect(result.current.isUploading).toBe(false);
   });
@@ -102,11 +106,13 @@ describe('usePhotoUpload Hook', () => {
 
     const { result } = renderHook(() => usePhotoUpload(mockToken));
     
+    let success = false;
     await act(async () => {
-      await result.current.uploadPhoto(mockFile, mockPhotoData);
+      success = await result.current.uploadPhoto(mockFile, mockPhotoData);
     });
     
     expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(success).toBe(false);
     expect(result.current.uploadError).toBe('Failed to upload file');
     expect(result.current.isUploading).toBe(false);
   });
@@ -136,11 +142,13 @@ describe('usePhotoUpload Hook', () => {
 
     const { result } = renderHook(() => usePhotoUpload(mockToken));
     
+    let success = false;
     await act(async () => {
-      await result.current.uploadPhoto(mockFile, mockPhotoData);
+      success = await result.current.uploadPhoto(mockFile, mockPhotoData);
     });
     
     expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(success).toBe(false);
     expect(result.current.uploadError).toBe('Failed to save photo information');
     expect(result.current.isUploading).toBe(false);
   });

--- a/src/components/PhotoUpload.tsx
+++ b/src/components/PhotoUpload.tsx
@@ -32,7 +32,7 @@ export default function PhotoUpload({ token, eventId, genre, onUploadComplete }:
       return;
     }
 
-    await uploadPhoto(file, {
+    const success = await uploadPhoto(file, {
       event_id: eventId,
       caption,
       alt_text: altText,
@@ -41,7 +41,7 @@ export default function PhotoUpload({ token, eventId, genre, onUploadComplete }:
     });
 
     // Reset form after successful upload
-    if (!uploadError) {
+    if (success) {
       setFile(null);
       setCaption('');
       setAltText('');

--- a/src/hooks/usePhotoUpload.ts
+++ b/src/hooks/usePhotoUpload.ts
@@ -20,7 +20,7 @@ interface UsePhotoUploadResult {
   isUploading: boolean;
   uploadProgress: number;
   uploadError: string | null;
-  uploadPhoto: (file: File, photoData: Omit<PhotoData, 'blob_url'>) => Promise<void>;
+  uploadPhoto: (file: File, photoData: Omit<PhotoData, 'blob_url'>) => Promise<boolean>;
 }
 
 export function usePhotoUpload(token: string): UsePhotoUploadResult {
@@ -31,7 +31,7 @@ export function usePhotoUpload(token: string): UsePhotoUploadResult {
   const uploadPhoto = async (file: File, photoData: Omit<PhotoData, 'blob_url'>) => {
     if (!token) {
       setUploadError('Authentication required');
-      return;
+      return false;
     }
 
     setIsUploading(true);
@@ -93,8 +93,10 @@ export function usePhotoUpload(token: string): UsePhotoUploadResult {
       }
 
       setUploadProgress(100);
+      return true;
     } catch (error) {
       setUploadError(error instanceof Error ? error.message : 'An unknown error occurred');
+      return false;
     } finally {
       setIsUploading(false);
     }


### PR DESCRIPTION
## Summary
- return a boolean from `usePhotoUpload` to indicate success
- clear the photo form in `PhotoUpload` only when upload succeeds
- update hook and component tests to expect the boolean return value

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686898107dd883249749709b8c0a36d6