### PR TITLE
Update tests for new site branding

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,6 +1,6 @@
 # Database Implementation
 
-This document describes the SQLite database implementation for the Band Pics application.
+This document describes the SQLite database implementation for the Buffalo Music Scene application.
 
 ## Overview
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Band Pics
+Copyright (c) 2025 Buffalo Music Scene
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Band Pics - Next.js Application
+# Buffalo Music Scene - Next.js Application
 
 A modern Next.js web application for organizing and displaying band pictures by genre, optimized for Vercel deployment.
 

--- a/__tests__/BandsinTownUI.test.tsx
+++ b/__tests__/BandsinTownUI.test.tsx
@@ -6,7 +6,7 @@ describe('Bandsintown UI', () => {
     render(<Home />);
     
     // Check for the new header elements
-    expect(screen.getByRole('heading', { level: 1, name: 'Band Pics' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Buffalo Music Scene' })).toBeInTheDocument();
     expect(screen.getByText('Sign Up')).toBeInTheDocument();
     expect(screen.getByText('Log In')).toBeInTheDocument();
     expect(screen.getByText('Discover Live Music Near You')).toBeInTheDocument();

--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -13,7 +13,7 @@ describe('Header Component', () => {
   it('renders the header with title and navigation', () => {
     render(<Header onSearch={mockOnSearch} onReset={mockOnReset} onShowPastEvents={mockOnShowPastEvents} />);
     
-    expect(screen.getByRole('heading', { name: 'Band Pics' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Buffalo Music Scene' })).toBeInTheDocument();
     expect(screen.getByText('Buffalo Events')).toBeInTheDocument();
     expect(screen.getByText('Social Feed')).toBeInTheDocument();
     expect(screen.getByText('Recent Concerts')).toBeInTheDocument();

--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -6,10 +6,10 @@ describe('Home Page', () => {
     render(<Home />);
     
     // Check for main sections
-    expect(screen.getByRole('heading', { level: 1, name: 'Band Pics' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Buffalo Music Scene' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Upcoming Events in Buffalo' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Buffalo Music Venue Social Feed' })).toBeInTheDocument();
-    expect(screen.getByText('© 2025 Band Pics. All rights reserved.')).toBeInTheDocument();
+    expect(screen.getByText("© 2025 Buffalo Music Scene. Celebrating the city's musical legacy.")).toBeInTheDocument();
     
     // Check for new Bandsintown-like sections
     expect(screen.getByText('Last Night\'s Concerts')).toBeInTheDocument();

--- a/backup/index.html
+++ b/backup/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Band Pics</title>
+    <title>Buffalo Music Scene</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
-        <h1>Band Pics</h1>
+        <h1>Buffalo Music Scene</h1>
         <nav>
             <ul>
                 <li><a href="#rock">Rock</a></li>
@@ -59,7 +59,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 Band Pics. All rights reserved.</p>
+        <p>&copy; 2025 Buffalo Music Scene. Celebrating the city's musical legacy.</p>
     </footer>
 
     <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Band Pics</title>
+    <title>Buffalo Music Scene</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
-        <h1>Band Pics</h1>
+        <h1>Buffalo Music Scene</h1>
         <nav>
             <ul>
                 <li><a href="#rock">Rock</a></li>
@@ -59,7 +59,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 Band Pics. All rights reserved.</p>
+        <p>&copy; 2025 Buffalo Music Scene. Celebrating the city's musical legacy.</p>
     </footer>
 
     <script src="script.js"></script>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Band Pics",
+  title: "Buffalo Music Scene",
   description: "A repository for storing and organizing band pictures",
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -52,7 +52,7 @@ export default function Header({ onSearch, onReset, onShowPastEvents }: HeaderPr
     <header className="bg-primary-900/90 backdrop-blur-sm text-white p-5 mb-5 border-b border-primary-700">
       <div className="max-w-6xl mx-auto">
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-3xl font-bold text-accent-400">Band Pics</h1>
+          <h1 className="text-3xl font-bold text-accent-400">Buffalo Music Scene</h1>
           
           <div className="flex items-center space-x-4">
             <button


### PR DESCRIPTION
## Summary
- adjust header expectation for Buffalo Music Scene title
- check updated footer text in page test
- update BandsinTown UI test title expectation
- update site metadata, header, and static pages for Buffalo Music Scene branding
- ensure tests end with newline for clean merges

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686898131ce0832493d742feae1d8788