### PR TITLE
Implement local image loading and events tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The application includes tests for:
 ### Adding New Genres
 1. Update the `GenreImages` interface in `src/hooks/useImages.ts`
 2. Add new navigation links in `src/components/Header.tsx`
-3. Add new Gallery components in `src/app/page.tsx`
+3. Add new Gallery components or pages such as `src/app/folk/page.tsx`
 
 ### Search Enhancement
 - Modify search logic in `src/components/Header.tsx`

--- a/public/images/events/events1.svg
+++ b/public/images/events/events1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#065f46" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Events 1
+  </text>
+</svg>

--- a/public/images/events/events2.svg
+++ b/public/images/events/events2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#065f46" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Events 2
+  </text>
+</svg>

--- a/public/images/events/events3.svg
+++ b/public/images/events/events3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#065f46" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Events 3
+  </text>
+</svg>

--- a/public/images/events/events4.svg
+++ b/public/images/events/events4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#065f46" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Events 4
+  </text>
+</svg>

--- a/public/images/folk/folk1.svg
+++ b/public/images/folk/folk1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#92400e" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Folk 1
+  </text>
+</svg>

--- a/public/images/folk/folk2.svg
+++ b/public/images/folk/folk2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#92400e" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Folk 2
+  </text>
+</svg>

--- a/public/images/folk/folk3.svg
+++ b/public/images/folk/folk3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#92400e" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Folk 3
+  </text>
+</svg>

--- a/public/images/folk/folk4.svg
+++ b/public/images/folk/folk4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#92400e" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Folk 4
+  </text>
+</svg>

--- a/public/images/jazz/jazz1.svg
+++ b/public/images/jazz/jazz1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#1e3a8a" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Jazz 1
+  </text>
+</svg>

--- a/public/images/jazz/jazz2.svg
+++ b/public/images/jazz/jazz2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#1e3a8a" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Jazz 2
+  </text>
+</svg>

--- a/public/images/jazz/jazz3.svg
+++ b/public/images/jazz/jazz3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#1e3a8a" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Jazz 3
+  </text>
+</svg>

--- a/public/images/jazz/jazz4.svg
+++ b/public/images/jazz/jazz4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#1e3a8a" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Jazz 4
+  </text>
+</svg>

--- a/public/images/pop/pop1.svg
+++ b/public/images/pop/pop1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#9d174d" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Pop 1
+  </text>
+</svg>

--- a/public/images/pop/pop2.svg
+++ b/public/images/pop/pop2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#9d174d" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Pop 2
+  </text>
+</svg>

--- a/public/images/pop/pop3.svg
+++ b/public/images/pop/pop3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#9d174d" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Pop 3
+  </text>
+</svg>

--- a/public/images/pop/pop4.svg
+++ b/public/images/pop/pop4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#9d174d" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Pop 4
+  </text>
+</svg>

--- a/public/images/rock/rock1.svg
+++ b/public/images/rock/rock1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#991b1b" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Rock 1
+  </text>
+</svg>

--- a/public/images/rock/rock2.svg
+++ b/public/images/rock/rock2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#991b1b" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Rock 2
+  </text>
+</svg>

--- a/public/images/rock/rock3.svg
+++ b/public/images/rock/rock3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#991b1b" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Rock 3
+  </text>
+</svg>

--- a/public/images/rock/rock4.svg
+++ b/public/images/rock/rock4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="300" height="200" fill="#991b1b" />
+  <text x="50%" y="50%" font-size="30" fill="#f9fafb" text-anchor="middle" dominant-baseline="central">
+    Rock 4
+  </text>
+</svg>

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const limit = parseInt(searchParams.get('limit') || '50');
     const offset = parseInt(searchParams.get('offset') || '0');
-    const events = eventModel.getEvents(limit, offset);
+    const events = eventModel.getEventsWithVenues(limit, offset);
     return NextResponse.json({ events, limit, offset });
   } catch (error) {
     console.error('Error fetching events:', error);

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { EventModel } from '@/lib/database';
+
+const eventModel = new EventModel();
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get('limit') || '50');
+    const offset = parseInt(searchParams.get('offset') || '0');
+    const events = eventModel.getEvents(limit, offset);
+    return NextResponse.json({ events, limit, offset });
+  } catch (error) {
+    console.error('Error fetching events:', error);
+    return NextResponse.json({ error: 'Failed to fetch events' }, { status: 500 });
+  }
+}

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -8,10 +8,10 @@ import Button from '@/components/Button';
 
 export default async function EventGalleryPage({ params }) {
   const eventId = params.id;
-  
+
   // Fetch event details
   const events = await getPastEvents();
-  const event = events.find(e => e.id === eventId);
+  const event = events.find(e => e.id === Number(eventId));
   
   if (!event) {
     return notFound();

--- a/src/app/folk/page.tsx
+++ b/src/app/folk/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import Gallery from '@/components/Gallery';
+import { useImages } from '@/hooks/useImages';
+
+export default function FolkPage() {
+  const images = useImages();
+  return (
+    <div className="max-w-6xl mx-auto p-4">
+      <Gallery title="Folk Bands" id="folk" images={images.folk} />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,7 @@
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.6;
   color: #f1f5f9;
   background-color: #0f172a;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -100,6 +100,11 @@ export default function Header({ onSearch, onReset, onShowPastEvents }: HeaderPr
                 </a>
               </li>
               <li>
+                <a href="#folk" className="text-primary-200 font-medium hover:text-accent-400 transition-colors no-underline">
+                  Folk
+                </a>
+              </li>
+              <li>
                 <a href="#events" className="text-primary-200 font-medium hover:text-accent-400 transition-colors no-underline">
                   Events
                 </a>

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -13,6 +13,7 @@ export interface GenreImages {
   rock: ImageData[];
   jazz: ImageData[];
   pop: ImageData[];
+  folk: ImageData[];
   events: ImageData[];
 }
 
@@ -21,25 +22,27 @@ export function useImages() {
     rock: [],
     jazz: [],
     pop: [],
+    folk: [],
     events: []
   });
 
   useEffect(() => {
-    // Simulate loading images - in a real app, this would fetch from an API
+    // Load images from the local public/images directory
     const loadImages = () => {
-      const genres = ['rock', 'jazz', 'pop', 'events'] as const;
+      const genres = ['rock', 'jazz', 'pop', 'folk', 'events'] as const;
       const newImages: GenreImages = {
         rock: [],
         jazz: [],
         pop: [],
+        folk: [],
         events: []
       };
 
-      genres.forEach(genre => {
+      genres.forEach((genre) => {
         for (let i = 1; i <= 4; i++) {
           newImages[genre].push({
             id: i,
-            src: `https://via.placeholder.com/300x200?text=${genre.charAt(0).toUpperCase() + genre.slice(1)}+Band+${i}`,
+            src: `/images/${genre}/${genre}${i}.svg`,
             alt: `${genre} band ${i}`,
             caption: `${genre.charAt(0).toUpperCase() + genre.slice(1)} Band ${i}`
           });

--- a/src/hooks/useVenueEvents.ts
+++ b/src/hooks/useVenueEvents.ts
@@ -12,33 +12,13 @@ export interface VenueEvent {
   source: string;
 }
 
-// List of Buffalo music venues and their APIs/sources
+// Venue sources are stored in the database; this constant remains for fallback labels
 const VENUE_SOURCES = [
-  {
-    name: 'Buffalo Iron Works',
-    apiUrl: 'https://api.example.com/buffaloironworks/events', // Example API URL
-    source: 'Buffalo Iron Works Website'
-  },
-  {
-    name: 'Town Ballroom',
-    apiUrl: 'https://api.example.com/townballroom/events', // Example API URL
-    source: 'Town Ballroom Website'
-  },
-  {
-    name: 'Mohawk Place',
-    apiUrl: 'https://api.example.com/mohawkplace/events', // Example API URL
-    source: 'Mohawk Place Website'
-  },
-  {
-    name: 'Sportsmen\'s Tavern',
-    apiUrl: 'https://api.example.com/sportsmenstavern/events', // Example API URL
-    source: 'Sportsmen\'s Tavern Website'
-  },
-  {
-    name: 'Kleinhans Music Hall',
-    apiUrl: 'https://api.example.com/kleinhans/events', // Example API URL
-    source: 'Kleinhans Music Hall Website'
-  }
+  { name: 'Buffalo Iron Works', source: 'Buffalo Iron Works Website' },
+  { name: 'Town Ballroom', source: 'Town Ballroom Website' },
+  { name: 'Mohawk Place', source: 'Mohawk Place Website' },
+  { name: "Sportsmen's Tavern", source: "Sportsmen's Tavern Website" },
+  { name: 'Kleinhans Music Hall', source: 'Kleinhans Music Hall Website' }
 ];
 
 export function useVenueEvents() {
@@ -50,38 +30,21 @@ export function useVenueEvents() {
     const fetchEvents = async () => {
       setLoading(true);
       setError(null);
-      
+
       try {
-        // In a real application, we would fetch from actual APIs
-        // For now, we'll simulate API responses with mock data
-        
-        // Simulated API response data
-        const mockEvents: VenueEvent[] = [];
-        
-        // Generate mock events for each venue
-        VENUE_SOURCES.forEach((venue, venueIndex) => {
-          // Create 3 events for each venue
-          for (let i = 1; i <= 3; i++) {
-            // Generate a date within the next 30 days
-            const eventDate = new Date();
-            eventDate.setDate(eventDate.getDate() + (venueIndex * 3) + i);
-            
-            mockEvents.push({
-              id: `${venueIndex}-${i}`,
-              title: `${['Rock', 'Jazz', 'Pop', 'Folk', 'Blues'][Math.floor(Math.random() * 5)]} Concert ${i}`,
-              date: eventDate.toISOString().split('T')[0],
-              venue: venue.name,
-              ticketUrl: `https://tickets.example.com/${venue.name.toLowerCase().replace(/\s+/g, '')}/event${i}`,
-              imageUrl: `https://via.placeholder.com/300x200?text=${venue.name.replace(/\s+/g, '+')}+Event+${i}`,
-              source: venue.source
-            });
-          }
-        });
-        
-        // Sort events by date (closest first)
-        mockEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-        
-        setEvents(mockEvents);
+        const res = await fetch('/api/events');
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        const eventsFromApi: VenueEvent[] = data.events.map((e: any) => ({
+          id: e.id.toString(),
+          title: e.title,
+          date: e.date,
+          venue: VENUE_SOURCES.find(v => v.name === e.venue)?.name || e.venue_id,
+          ticketUrl: '',
+          imageUrl: e.image_url || '/images/events/events1.svg',
+          source: 'Local Database'
+        }));
+        setEvents(eventsFromApi);
       } catch (err) {
         console.error('Error fetching venue events:', err);
         setError('Failed to load upcoming events. Please try again later.');

--- a/src/hooks/useVenueEvents.ts
+++ b/src/hooks/useVenueEvents.ts
@@ -39,7 +39,7 @@ export function useVenueEvents() {
           id: e.id.toString(),
           title: e.title,
           date: e.date,
-          venue: VENUE_SOURCES.find(v => v.name === e.venue)?.name || e.venue_id,
+          venue: e.venue,
           ticketUrl: '',
           imageUrl: e.image_url || '/images/events/events1.svg',
           source: 'Local Database'

--- a/src/lib/database/index.ts
+++ b/src/lib/database/index.ts
@@ -1,3 +1,3 @@
 export { getDatabase, closeDatabase } from './connection';
-export { UserModel, SessionModel, PostModel, PhotoModel } from './models';
+export { UserModel, SessionModel, PostModel, PhotoModel, EventModel, VenueModel } from './models';
 export * from './types';

--- a/src/lib/database/models/event.ts
+++ b/src/lib/database/models/event.ts
@@ -10,6 +10,10 @@ export interface Event {
   updated_at: string;
 }
 
+export interface EventWithVenue extends Event {
+  venue: string;
+}
+
 export interface CreateEventData {
   venue_id: number;
   title: string;
@@ -47,11 +51,25 @@ export class EventModel {
     return stmt.get(id) as Event | null;
   }
 
+  getEventWithVenue(id: number): EventWithVenue | null {
+    const stmt = this.db.prepare(
+      `SELECT e.*, v.name AS venue FROM events e JOIN venues v ON e.venue_id = v.id WHERE e.id = ?`
+    );
+    return stmt.get(id) as EventWithVenue | null;
+  }
+
   getEvents(limit: number = 50, offset: number = 0): Event[] {
     const stmt = this.db.prepare(
       'SELECT * FROM events ORDER BY date DESC LIMIT ? OFFSET ?'
     );
     return stmt.all(limit, offset) as Event[];
+  }
+
+  getEventsWithVenues(limit: number = 50, offset: number = 0): EventWithVenue[] {
+    const stmt = this.db.prepare(
+      `SELECT e.*, v.name AS venue FROM events e JOIN venues v ON e.venue_id = v.id ORDER BY date DESC LIMIT ? OFFSET ?`
+    );
+    return stmt.all(limit, offset) as EventWithVenue[];
   }
 
   getEventsByVenue(venueId: number, limit: number = 50, offset: number = 0): Event[] {
@@ -85,12 +103,12 @@ export class EventModel {
   }
 }
 
-export async function getPastEvents(): Promise<Event[]> {
+export async function getPastEvents(limit: number = 50, offset: number = 0): Promise<EventWithVenue[]> {
   const model = new EventModel();
-  return model.getEvents();
+  return model.getEventsWithVenues(limit, offset);
 }
 
-export async function getEventById(id: string): Promise<Event | null> {
+export async function getEventById(id: string): Promise<EventWithVenue | null> {
   const model = new EventModel();
-  return model.getEventById(Number(id));
+  return model.getEventWithVenue(Number(id));
 }

--- a/src/lib/database/models/index.ts
+++ b/src/lib/database/models/index.ts
@@ -2,4 +2,5 @@ export { UserModel } from './user';
 export { SessionModel } from './session';
 export { PostModel } from './post';
 export * from './event';
+export { VenueModel } from './venue';
 export { PhotoModel } from './photo';

--- a/src/lib/database/models/venue.ts
+++ b/src/lib/database/models/venue.ts
@@ -1,0 +1,43 @@
+import { getDatabase } from '../connection';
+
+export interface Venue {
+  id: number;
+  name: string;
+  location?: string | null;
+  website?: string | null;
+  created_at: string;
+}
+
+export interface CreateVenueData {
+  name: string;
+  location?: string;
+  website?: string;
+}
+
+export class VenueModel {
+  private db = getDatabase();
+
+  createVenue(data: CreateVenueData): Venue {
+    const stmt = this.db.prepare(
+      `INSERT INTO venues (name, location, website) VALUES (?, ?, ?)`
+    );
+    const result = stmt.run(
+      data.name,
+      data.location || null,
+      data.website || null
+    );
+    const venue = this.getVenueById(result.lastInsertRowid as number);
+    if (!venue) throw new Error('Failed to create venue');
+    return venue;
+  }
+
+  getVenueById(id: number): Venue | null {
+    const stmt = this.db.prepare('SELECT * FROM venues WHERE id = ?');
+    return stmt.get(id) as Venue | null;
+  }
+
+  getAllVenues(): Venue[] {
+    const stmt = this.db.prepare('SELECT * FROM venues ORDER BY name');
+    return stmt.all() as Venue[];
+  }
+}

--- a/src/lib/database/schema.sql
+++ b/src/lib/database/schema.sql
@@ -79,6 +79,27 @@ CREATE TABLE IF NOT EXISTS photos (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+-- Venues table for music venues
+CREATE TABLE IF NOT EXISTS venues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    location TEXT,
+    website TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Events table linking to venues
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    venue_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    date DATETIME NOT NULL,
+    image_url TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (venue_id) REFERENCES venues(id) ON DELETE CASCADE
+);
+
 -- Indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
@@ -98,3 +119,6 @@ CREATE INDEX IF NOT EXISTS idx_photos_user_id ON photos(user_id);
 CREATE INDEX IF NOT EXISTS idx_photos_event_id ON photos(event_id);
 CREATE INDEX IF NOT EXISTS idx_photos_genre ON photos(genre);
 CREATE INDEX IF NOT EXISTS idx_photos_created_at ON photos(created_at);
+CREATE INDEX IF NOT EXISTS idx_events_date ON events(date);
+CREATE INDEX IF NOT EXISTS idx_events_venue_id ON events(venue_id);
+CREATE INDEX IF NOT EXISTS idx_venues_name ON venues(name);

--- a/src/lib/database/types.ts
+++ b/src/lib/database/types.ts
@@ -161,6 +161,10 @@ export interface UpdateEventData {
   image_url?: string;
 }
 
+export interface EventWithVenue extends Event {
+  venue: string;
+}
+
 export interface CreatePhotoData {
   user_id: number;
   event_id?: number;

--- a/src/lib/database/types.ts
+++ b/src/lib/database/types.ts
@@ -123,6 +123,44 @@ export interface Photo {
   updated_at: string;
 }
 
+export interface Venue {
+  id: number;
+  name: string;
+  location?: string | null;
+  website?: string | null;
+  created_at: string;
+}
+
+export interface CreateVenueData {
+  name: string;
+  location?: string;
+  website?: string;
+}
+
+export interface Event {
+  id: number;
+  venue_id: number;
+  title: string;
+  date: string;
+  image_url?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateEventData {
+  venue_id: number;
+  title: string;
+  date: string;
+  image_url?: string;
+}
+
+export interface UpdateEventData {
+  venue_id?: number;
+  title?: string;
+  date?: string;
+  image_url?: string;
+}
+
 export interface CreatePhotoData {
   user_id: number;
   event_id?: number;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,9 @@ const config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'Poppins', 'ui-sans-serif', 'system-ui'],
+      },
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',


### PR DESCRIPTION
## Summary
- add local SVG band images in `public/images`
- extend `useImages` with real file paths and new `folk` genre
- expose new `folk` gallery page and navigation link
- tweak fonts and theme configuration
- create SQLite tables/models for venues and events
- add events API and update `useVenueEvents` to fetch from it
- update schema and documentation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686899420758832488e94db8f2627719